### PR TITLE
Fix MSVC warnings compiling latex.c

### DIFF
--- a/src/latex.c
+++ b/src/latex.c
@@ -173,7 +173,7 @@ static link_type get_link_type(cmark_node *node) {
   link_text = node->first_child;
   cmark_consolidate_text_nodes(link_text);
   realurl = (char *)url;
-  realurllen = url_len;
+  realurllen = (int)url_len;
   if (strncmp(realurl, "mailto:", 7) == 0) {
     realurl += 7;
     realurllen -= 7;


### PR DESCRIPTION
Port of https://github.com/jgm/cmark/pull/165

Fixes the following build warnings:
```
[25/65] Building C object src\CMakeFiles\libcmark_static.dir\latex.c.obj
C:\Users\hughb\Documents\GitHub\my-swift\cmark\src\latex.c(176): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
[37/65] Building C object src\CMakeFiles\cmark.dir\latex.c.obj
C:\Users\hughb\Documents\GitHub\my-swift\cmark\src\latex.c(176): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
[49/65] Building C object src\CMakeFiles\libcmark.dir\latex.c.obj
C:\Users\hughb\Documents\GitHub\my-swift\cmark\src\latex.c(176): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
[61/65] Linking C shared library src\cmark.dll
   Creating library src\cmark.lib and object src\cmark.exp
   Creating library src\cmark.lib and object src\cmark.exp
[65/65] Linking CXX executable api_test\api_test.exe
```

@jrose-apple 