### PR TITLE
[CMake] Export the CMark targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,6 +130,9 @@ install(FILES
   DESTINATION include
   )
 
+export(TARGETS ${PROGRAM} ${LIBRARY} ${STATICLIBRARY}
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/CMarkExports.cmake)
+
 # Feature tests
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)


### PR DESCRIPTION
This creates a CMarkExports.cmake file that exports the cmark library and executable targets. This can be consumed by Swift so that Swift can depend on CMark's targets without needing to specify the absolute paths to libraries.