### PR TITLE
Update cmark_version.h

### DIFF
--- a/src/include/cmark_version.h
+++ b/src/include/cmark_version.h
@@ -1,7 +1,7 @@
 #ifndef CMARK_VERSION_H
 #define CMARK_VERSION_H
 
-#define CMARK_VERSION ((0 << 16) | (28 << 8) | 3)
-#define CMARK_VERSION_STRING "0.28.3"
+#define CMARK_VERSION ((0 << 16) | (29 << 8) | 0)
+#define CMARK_VERSION_STRING "0.29.0"
 
 #endif


### PR DESCRIPTION
Change from 0.28.3 to 0.29.0 to match the [CMakeLists.txt](https://github.com/apple/swift-cmark/blob/1168665f6b36be747ffe6b7b90bc54cfc17f42b7/CMakeLists.txt#L2) project version.

See also: apple/swift-cmark#10