### PR TITLE
Restore footnote functionality

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -1283,16 +1283,63 @@ noMatch:
   if (parser->options & CMARK_OPT_FOOTNOTES &&
       opener->inl_text->next &&
       opener->inl_text->next->type == CMARK_NODE_TEXT &&
-      !opener->inl_text->next->next) {
-    cmark_chunk *literal = &opener->inl_text->next->as.literal;
-    if (literal->len > 1 && literal->data[0] == '^') {
-      inl = make_simple(subj->mem, CMARK_NODE_FOOTNOTE_REFERENCE);
-      inl->as.literal = cmark_chunk_dup(literal, 1, literal->len - 1);
-      inl->start_line = inl->end_line = subj->line;
-      inl->start_column = opener->inl_text->start_column;
-      inl->end_column = subj->pos + subj->column_offset + subj->block_offset;
-      cmark_node_insert_before(opener->inl_text, inl);
-      cmark_node_free(opener->inl_text->next);
+      opener->inl_text->next->next &&
+      opener->inl_text->next->next->type == CMARK_NODE_TEXT) {
+    cmark_chunk *footnote = &opener->inl_text->next->as.literal;
+    cmark_chunk *literal = &opener->inl_text->next->next->as.literal;
+
+    // look back to the opening '[', and skip ahead to the next character
+    // if we're looking at a '[^' sequence, and there is other text or nodes
+    // after the ^, let's call it a footnote reference.
+    if (footnote->len == 1 && footnote->data[0] == '^' && (literal->len > 1 || opener->inl_text->next->next)) {
+
+      cmark_node *fnref = make_simple(subj->mem, CMARK_NODE_FOOTNOTE_REFERENCE);
+
+      // the start and end of the footnote ref is the opening and closing brace
+      // i.e. the subject's current position, and the opener's start_column
+      int fnref_end_column = subj->pos + subj->column_offset + subj->block_offset;
+      int fnref_start_column = opener->inl_text->start_column;
+
+      // any given node delineates a substring of the line being processed,
+      // with the remainder of the line being pointed to thru its 'literal'
+      // struct member.
+      // here, we copy the literal's pointer, moving it past the '^' character
+      // for a length equal to the size of footnote reference text.
+      // i.e. end_col minus start_col, minus the [ and the ^ characters
+      //
+      // this copies the footnote reference string, even if between the
+      // `opener` and the subject's current position there are other nodes
+      fnref->as.literal = cmark_chunk_dup(literal, 0, (fnref_end_column - fnref_start_column) - 2);
+
+      fnref->start_line = fnref->end_line = subj->line;
+      fnref->start_column = fnref_start_column;
+      fnref->end_column = fnref_end_column;
+
+      // we then replace the opener with this new fnref node, the net effect
+      // being replacing the opening '[' text node with a `^footnote-ref]` node.
+      cmark_node_insert_before(opener->inl_text, fnref);
+
+      // sometimes, the footnote reference text gets parsed into multiple nodes
+      // i.e. '[^example]' parsed into '[', '^exam', 'ple]'.
+      // this happens for ex with the autolink extension. when the autolinker
+      // finds the 'w' character, it will split the text into multiple nodes
+      // in hopes of being able to match a 'www.' substring.
+      //
+      // because this function is called one character at a time via the
+      // `parse_inlines` function, and the current subj->pos is pointing at the
+      // closing ] brace, and because we copy all the text between the [ ]
+      // braces, we should be able to safely ignore and delete any nodes after
+      // the opener->inl_text->next.
+      //
+      // therefore, here we walk thru the list and free them all up
+      cmark_node *next_node;
+      cmark_node *current_node = opener->inl_text->next;
+      while(current_node) {
+        next_node = current_node->next;
+        cmark_node_free(current_node);
+        current_node = next_node;
+      }
+
       cmark_node_free(opener->inl_text);
       process_emphasis(parser, subj, opener->previous_delimiter);
       pop_bracket(subj);


### PR DESCRIPTION
This restores the functionality of the footnote extension[^1].

Note that footnote reference and definition nodes are currently not exposed through `cmark_node_get_type_string` so more work would be required to get them to work in [SwiftMarkdown](https://github.com/apple/swift-markdown).

Tested this locally by parsing footnotes with this change set in [a branch of my website](https://github.com/robb/robb.swift/commit/15949914b9017adde01b7e5eea0bee51dd78be56), I don't have the ability to run the test suite atm.

[^1]: I didn't know GFM had this until today!