### PR TITLE
allow extensions to use `!` and `^` as special characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ mingw:
 	cmake .. -DCMAKE_TOOLCHAIN_FILE=../toolchain-mingw32.cmake -DCMAKE_INSTALL_PREFIX=$(MINGW_INSTALLDIR) ;\
 	$(MAKE) && $(MAKE) install
 
-man/man3/cmark-gfm.3: src/cmark-gfm.h | $(CMARK)
+man/man3/cmark-gfm.3: src/include/cmark-gfm.h | $(CMARK)
 	python man/make_man_page.py $< > $@ \
 
 archive:


### PR DESCRIPTION
While implementing updates for https://github.com/apple/swift-cmark/pull/28, and while verifying changes for https://github.com/apple/swift-cmark/pull/29, i noticed that some special characters weren't being handled properly, and couldn't be used by extensions. This updates the `parse_inline` function to allow `^` and `!` to be used as special characters by extensions. This also allows footnotes to work with our implementation of inline attributes, allowing the full test suite to pass.