### PR TITLE
[gfm] add thread-safety support for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(CMARK_TESTS "Build cmark-gfm tests and enable testing" ON)
 option(CMARK_STATIC "Build static libcmark-gfm library" ON)
 option(CMARK_SHARED "Build shared libcmark-gfm library" ON)
 option(CMARK_LIB_FUZZER "Build libFuzzer fuzzing harness" OFF)
-option(CMARK_THREADING "Add locks around static accesses via pthreads" OFF)
+option(CMARK_THREADING "Add locks around static accesses" OFF)
 
 add_subdirectory(src)
 add_subdirectory(extensions)


### PR DESCRIPTION
The `CMARK_THREADING` feature in our cmark-gfm branch currently uses pthreads to synchronize accesses to shared state. This causes a problem when building on Windows, since this library is not available there. This PR updates `mutex.h` to load Win32 SRW Locks and one-time initialization support in lieu of pthreads when building for Windows.