### PR TITLE
build: adjust build rules for Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,22 @@
 
 import PackageDescription
 
+#if os(Windows)
+#if arch(i386) || arch(x86_64)
+    let cSettings: [CSetting] = [
+        .define("_X86_", .when(platforms: [.windows])),
+    ]
+#elseif arch(arm) || arch(arm64)
+    let cSettings: [CSetting] = [
+        .define("_ARM_", .when(platforms: [.windows])),
+    ]
+#else
+#error("unsupported architecture")
+#endif
+#else
+    let cSettings: [CSetting] = []
+#endif
+
 let package = Package(
     name: "cmark-gfm",
     products: [
@@ -30,7 +46,8 @@ let package = Package(
             "cmark-gfm_version.h.in",
             "case_fold_switch.inc",
             "entities.inc",
-          ]
+          ],
+          cSettings: cSettings
         ),
         .target(name: "cmark-gfm-extensions",
           dependencies: [
@@ -40,7 +57,8 @@ let package = Package(
           exclude: [
             "CMakeLists.txt",
             "ext_scanners.re",
-          ]
+          ],
+          cSettings: cSettings
         ),
         .target(name: "cmark-gfm-bin",
           dependencies: [


### PR DESCRIPTION
Because we do not use `cl` from MSVC or `clang-cl`, we lose some of the
necessary target macros.  This manually constructs the macro definitions
to allow building the C/C++ code on Windows.  This is required in
addition to apple/swift-cmark#34 to build the gfm branch.