### PR TITLE
add build settings to build properly on linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,10 @@ let package = Package(
             "case_fold_switch.inc",
             "entities.inc",
           ],
-          cSettings: cSettings
+          cSettings: cSettings,
+          linkerSettings: [
+              .linkedLibrary("pthread", .when(platforms: [.linux])),
+          ]
         ),
         .target(name: "cmark-gfm-extensions",
           dependencies: [

--- a/src/include/module.modulemap
+++ b/src/include/module.modulemap
@@ -1,4 +1,4 @@
-module cmark_gfm {
+module cmark_gfm [extern_c] {
     umbrella header "cmark-gfm.h"
     header "cmark-gfm_config.h"
     header "cmark-gfm-extension_api.h"


### PR DESCRIPTION
When building with `swift build` on Linux, the `api_test` target will fail to build for two reasons:

- There is a missing reference to link `pthreads`
- The `cmark_gfm` module is not labeled as `extern_c`, and it causes an error when being imported in the C++ tests

This PR fixes those two issues.