### PR TITLE
various fixes for footnotes

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -1249,11 +1249,14 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
                parser->options & CMARK_OPT_FOOTNOTES &&
                (matched = scan_footnote_definition(input, parser->first_nonspace))) {
       cmark_chunk c = cmark_chunk_dup(input, parser->first_nonspace + 2, matched - 2);
-      cmark_chunk_to_cstr(parser->mem, &c);
 
       while (c.data[c.len - 1] != ']')
         --c.len;
       --c.len;
+
+      // Allocate the cstr rendering after the length adjustment so that the
+      // length is accurate when `cmark_node_get_literal` is called.
+      cmark_chunk_to_cstr(parser->mem, &c);
 
       S_advance_offset(parser, input, parser->first_nonspace + matched - parser->offset, false);
       *container = add_child(parser, *container, CMARK_NODE_FOOTNOTE_DEFINITION, parser->first_nonspace + matched + 1);

--- a/src/include/cmark-gfm.h
+++ b/src/include/cmark-gfm.h
@@ -368,6 +368,11 @@ CMARK_GFM_EXPORT const char *cmark_node_get_literal(cmark_node *node);
  */
 CMARK_GFM_EXPORT int cmark_node_get_backtick_count(cmark_node *node);
 
+/** If 'node' is a footnote reference or footnote definition, reutrns the
+    string ID of that footnote, otherwise returns NULL.
+ */
+CMARK_GFM_EXPORT const char *cmark_node_get_footnote_id(cmark_node *node);
+
 /** Sets the string contents of 'node'.  Returns 1 on success,
  * 0 on failure.
  */

--- a/src/node.c
+++ b/src/node.c
@@ -313,6 +313,10 @@ const char *cmark_node_get_type_string(cmark_node *node) {
     return "link";
   case CMARK_NODE_IMAGE:
     return "image";
+  case CMARK_NODE_FOOTNOTE_REFERENCE:
+    return "footnote_reference";
+  case CMARK_NODE_FOOTNOTE_DEFINITION:
+    return "footnote_definition";
   case CMARK_NODE_ATTRIBUTE:
     return "attribute";
   }

--- a/src/node.c
+++ b/src/node.c
@@ -462,6 +462,24 @@ int cmark_node_set_literal(cmark_node *node, const char *content) {
   return 0;
 }
 
+const char *cmark_node_get_footnote_id(cmark_node *node) {
+  if (node == NULL)
+    return NULL;
+
+  switch (node->type) {
+  case CMARK_NODE_FOOTNOTE_DEFINITION:
+    return cmark_chunk_to_cstr(NODE_MEM(node), &node->as.literal);
+
+  case CMARK_NODE_FOOTNOTE_REFERENCE:
+    return cmark_chunk_to_cstr(NODE_MEM(node->parent_footnote_def), &node->parent_footnote_def->as.literal);
+
+  default:
+    break;
+  }
+
+  return NULL;
+}
+
 const char *cmark_node_get_string_content(cmark_node *node) {
   return (char *) node->content.ptr;
 }

--- a/src/xml.c
+++ b/src/xml.c
@@ -137,6 +137,16 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
     case CMARK_NODE_ATTRIBUTE:
       // TODO
       break;
+    case CMARK_NODE_FOOTNOTE_DEFINITION:
+      cmark_strbuf_puts(xml, " id=\"");
+      escape_xml(xml, node->as.literal.data, node->as.literal.len);
+      cmark_strbuf_putc(xml, '"');
+      break;
+    case CMARK_NODE_FOOTNOTE_REFERENCE:
+      cmark_strbuf_puts(xml, " id=\"");
+      escape_xml(xml, node->parent_footnote_def->as.literal.data,
+                 node->parent_footnote_def->as.literal.len);
+      cmark_strbuf_putc(xml, '"');
     default:
       break;
     }


### PR DESCRIPTION
This PR adds a handful of fixes and improvements surrounding footnotes:

- Footnote definition and reference nodes now properly report a node type in `cmark_node_get_type_string`.
- XML output now emits the footnote IDs for footnote definitions and references.
- The "literal" string for footnote definitions (which holds the ID for the footnote) is now cached after the length adjustment that trims the trailing `]: ` from the text, allowing `cmark_chunk_to_cstr` to be called on these literals correctly.
- A new API, `cmark_node_get_footnote_id` has been added which returns the footnote ID for footnote definition and reference nodes. This can be used to easily load the authored footnote ID so that they can be matched with each other.

These changes are necessary for adding footnote support to Swift-Markdown and Swift-DocC.