### PR TITLE
NFC: Move `#include`s out of `extern "C"` block

### DIFF
--- a/src/include/cmark-gfm-extension_api.h
+++ b/src/include/cmark-gfm-extension_api.h
@@ -1,13 +1,13 @@
 #ifndef CMARK_GFM_EXTENSION_API_H
 #define CMARK_GFM_EXTENSION_API_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "cmark-gfm.h"
 
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct cmark_renderer;
 struct cmark_html_renderer;

--- a/src/include/cmark_ctype.h
+++ b/src/include/cmark_ctype.h
@@ -1,11 +1,11 @@
 #ifndef CMARK_CMARK_CTYPE_H
 #define CMARK_CMARK_CTYPE_H
 
+#include "export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "export.h"
 
 /** Locale-independent versions of functions from ctype.h.
  * We want cmark to behave the same no matter what the system locale.

--- a/src/include/houdini.h
+++ b/src/include/houdini.h
@@ -1,13 +1,13 @@
 #ifndef CMARK_HOUDINI_H
 #define CMARK_HOUDINI_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 
 #include "buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifdef HOUDINI_USE_LOCALE
 #define _isxdigit(c) isxdigit(c)

--- a/src/include/inlines.h
+++ b/src/include/inlines.h
@@ -1,14 +1,14 @@
 #ifndef CMARK_INLINES_H
 #define CMARK_INLINES_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdlib.h>
 
 #include "references.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 cmark_chunk cmark_clean_url(cmark_mem *mem, cmark_chunk *url);
 cmark_chunk cmark_clean_title(cmark_mem *mem, cmark_chunk *title);

--- a/src/include/iterator.h
+++ b/src/include/iterator.h
@@ -1,11 +1,11 @@
 #ifndef CMARK_ITERATOR_H
 #define CMARK_ITERATOR_H
 
+#include "cmark-gfm.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "cmark-gfm.h"
 
 typedef struct {
   cmark_event_type ev_type;

--- a/src/include/node.h
+++ b/src/include/node.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_NODE_H
 #define CMARK_NODE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -13,6 +9,10 @@ extern "C" {
 #include "cmark-gfm-extension_api.h"
 #include "buffer.h"
 #include "chunk.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct {
   cmark_list_type list_type;

--- a/src/include/plugin.h
+++ b/src/include/plugin.h
@@ -1,12 +1,12 @@
 #ifndef CMARK_PLUGIN_H
 #define CMARK_PLUGIN_H
 
+#include "cmark-gfm.h"
+#include "cmark-gfm-extension_api.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "cmark-gfm.h"
-#include "cmark-gfm-extension_api.h"
 
 /**
  * cmark_plugin:

--- a/src/include/registry.h
+++ b/src/include/registry.h
@@ -1,12 +1,12 @@
 #ifndef CMARK_REGISTRY_H
 #define CMARK_REGISTRY_H
 
+#include "cmark-gfm.h"
+#include "cmark-gfm-extension_api.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "cmark-gfm.h"
-#include "cmark-gfm-extension_api.h"
 
 CMARK_GFM_EXPORT
 void cmark_register_plugin(cmark_plugin_init_func reg_fn);

--- a/src/include/render.h
+++ b/src/include/render.h
@@ -1,15 +1,15 @@
 #ifndef CMARK_RENDER_H
 #define CMARK_RENDER_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdlib.h>
 
 #include "buffer.h"
 #include "chunk.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef enum { LITERAL, NORMAL, TITLE, URL } cmark_escaping;
 


### PR DESCRIPTION
This fixes a clang compiler error when using these headers in C++ language mode:
```
libcmark_gfm/include/registry.h:8:1: error: import of C++ module 'libcmark_gfm' appears within extern "C" language linkage specification
#include "cmark-gfm.h"
```

rdar://109730567