### PR TITLE
Fix excluded required source file in `cmark-gfm`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,8 +53,6 @@ let package = Package(
             "config.h.in",
             "CMakeLists.txt",
             "cmark-gfm_version.h.in",
-            "case_fold_switch.inc",
-            "entities.inc",
           ],
           cSettings: cSettings
         ),


### PR DESCRIPTION
Fixes an excluded source file in `cmark-gfm` that is required by [utf8.c](https://github.com/apple/swift-cmark/blob/gfm/src/utf8.c#L237).

> Running `swift build` on `swift-cmark` succeeds. This succeeds because clang defaults to looking in the source file's directory when resolving includes. The clang invocation is:

```
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -fobjc-arc -target x86_64-apple-macosx10.13 -g -O0 -DSWIFT_PACKAGE=1 -DDEBUG=1 -fblocks -index-store-path /Users/chuck/code/apple/swift-cmark/.build/x86_64-apple-macosx/debug/index/store -fmodules -fmodule-name=cmark_gfm -I /Users/chuck/code/apple/swift-cmark/src/include -fmodules-cache-path=/Users/chuck/code/apple/swift-cmark/.build/x86_64-apple-macosx/debug/ModuleCache -isysroot /Applications/Xcode-14.2.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk -F /Applications/Xcode-14.2.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -fPIC -MD -MT dependencies -MF /Users/chuck/code/apple/swift-cmark/.build/x86_64-apple-macosx/debug/cmark_gfm.build/utf8.c.d -c /Users/chuck/code/apple/swift-cmark/src/utf8.c -o /Users/chuck/code/apple/swift-cmark/.build/x86_64-apple-macosx/debug/cmark_gfm.build/utf8.c.
```

Reported in: https://github.com/cgrindel/rules_swift_package_manager/issues/400