### PR TITLE
build: install the modulemap

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -74,9 +74,9 @@ install(TARGETS ${CMARK_INSTALL}
 
 if (CMARK_SHARED OR CMARK_STATIC)
   install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/cmark-gfm-core-extensions.h
-  DESTINATION include
-  )
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/cmark-gfm-core-extensions.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap
+    DESTINATION include/cmark_gfm_extensions)
 
   install(EXPORT cmark-gfm-extensions DESTINATION lib${LIB_SUFFIX}/cmake-gfm-extensions)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,11 +149,31 @@ if(CMARK_SHARED OR CMARK_STATIC)
     DESTINATION ${libdir}/pkgconfig)
 
   install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/buffer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/chunk.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/cmark_ctype.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/cmark-gfm.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/cmark-gfm_config.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/cmark-gfm-extension_api.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/export.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/cmark-gfm_version.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/export.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/footnotes.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/houdini.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/html.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/inlines.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/iterator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/map.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/mutex.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/node.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/parser.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/plugin.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/references.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/registry.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/render.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/scanners.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/syntax_extension.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/utf8.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap
     DESTINATION include
     )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -174,7 +174,7 @@ if(CMARK_SHARED OR CMARK_STATIC)
     ${CMAKE_CURRENT_SOURCE_DIR}/include/syntax_extension.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/utf8.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap
-    DESTINATION include
+    DESTINATION include/cmark_gfm
     )
 
   install(EXPORT cmark-gfm DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)


### PR DESCRIPTION
The Swift fork has introduced a modulemap which is expected for some usage (primarily swift-markdown).  This adds the modulemap to the installation set.