### PR TITLE
build: adjust the cmark extensions build for vendoring

### DIFF
--- a/extensions/include/module.modulemap
+++ b/extensions/include/module.modulemap
@@ -1,0 +1,5 @@
+
+module cmark_gfm_extensions {
+  header "cmark-gfm-core-extensions.h"
+}
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,10 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
 if (CMARK_SHARED)
   add_library(${LIBRARY} SHARED ${LIBRARY_SOURCES})
+  target_include_directories(${LIBRARY} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/extensions/include>)
+
   # Include minor version and patch level in soname for now.
   set_target_properties(${LIBRARY} PROPERTIES
     OUTPUT_NAME "cmark-gfm"
@@ -101,6 +105,10 @@ endif()
 
 if (CMARK_STATIC)
   add_library(${STATICLIBRARY} STATIC ${LIBRARY_SOURCES})
+  target_include_directories(${LIBRARY} PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/extensions/include>)
+
   set_target_properties(${STATICLIBRARY} PROPERTIES
     COMPILE_FLAGS -DCMARK_GFM_STATIC_DEFINE
     POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Add missing include paths to be used when building this library in a larger CMake project.  Add a missing module.modulemap for the extensions library.  This is the first step towards enabling building swift-markdown with CMake which is to enable building swift-format via CMake for use in the LSP.