### PR TITLE
build: remove extra defines on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,23 +4,12 @@
 import PackageDescription
 
 #if os(Windows)
-#if arch(i386) || arch(x86_64)
-    var cSettings: [CSetting] = [
-        .define("_X86_", .when(platforms: [.windows])),
-    ]
-#elseif arch(arm) || arch(arm64)
-    var cSettings: [CSetting] = [
-        .define("_ARM_", .when(platforms: [.windows])),
-    ]
-#else
-#error("unsupported architecture")
-#endif
     // When building the library on Windows, we do not have proper control of
     // whether it is being built statically or dynamically.  However, given the
     // current default of static, we will assume that we are building
     // statically.  More importantly, should this not hold, this will fail at
     // link time.
-    cSettings += [
+    let cSettings: [CSetting] = [
         .define("CMARK_GFM_STATIC_DEFINE", .when(platforms: [.windows])),
         .define("CMARK_GFM_EXTENSIONS_STATIC_DEFINE", .when(platforms: [.windows])),
     ]


### PR DESCRIPTION
These should be provided by the proper inclusion of `Windows.h`.  This seems to currently properly function without the macros, so remove the extra macros.