### PR TITLE
build: include `include` in `INTERFACE_INCLUDE_DIRECTORIES`

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(libcmark-gfm-extensions
   tasklist.c)
 target_compile_definitions(libcmark-gfm-extensions PUBLIC
   $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:CMARK_GFM_STATIC_DEFINE>)
+target_include_directories(libcmark-gfm-extensions PUBLIC
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cmark_gfm_extensions>)
 target_link_libraries(libcmark-gfm-extensions PRIVATE
   libcmark-gfm)
 set_target_properties(libcmark-gfm-extensions PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,8 @@ endif()
 target_include_directories(libcmark-gfm PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/include>
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/extensions/include>)
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/extensions/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cmark_gfm>)
   target_link_libraries(libcmark-gfm PRIVATE
     $<$<BOOL:${THREADS_FOUND}>:Threads::Threads>)
 set_target_properties(libcmark-gfm PROPERTIES


### PR DESCRIPTION
This is require to build against the non-CONFIG form of the library.