### PR TITLE
Add define for GNU glibc extensions

### DIFF
--- a/api_test/harness.c
+++ b/api_test/harness.c
@@ -1,4 +1,7 @@
-#define _DEFAULT_SOURCE
+// _GNU_SOURCE is all ISO/POSIX/XOPEN/BSD/SVID + GNU extensions. It also sets
+// _DEFAULT_SOURCE on newer glibc. We need this for strdup/snprintf/fdopen/etc.
+#define _GNU_SOURCE
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
`fdopen`, `strdup`, and `mkstemp` are all extensions. `_DEFAULT_SOURCE` should be enough for this, but apparently not on older glibcs.