### PR TITLE
build: add cmark-gfm-config to allow wiring up builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,11 @@ if(CMARK_FUZZ_QUADRATIC)
   add_subdirectory(fuzz)
 endif()
 
-export(TARGETS libcmark-gfm libcmark-gfm-extensions
-  FILE cmark-gfmConfig.cmake)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmark-gfm-config.cmake.in
+  ${CMAKE_BINARY_DIR}/cmake/modules/cmark-gfm-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+install(FILES
+  ${CMAKE_BINARY_DIR}/cmake/modules/cmark-gfm-config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 

--- a/cmark-gfm-config.cmake.in
+++ b/cmark-gfm-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+include(${CMAKE_CURRENT_LIST_DIR}/cmark-gfm/cmark-gfm.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/cmark-gfm-extensions/cmark-gfm-extensions.cmake)

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -33,4 +33,4 @@ install(FILES
   include/module.modulemap
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cmark_gfm_extensions)
 install(EXPORT cmark-gfm-extensions
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake-gfm-extensions)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cmark-gfm-extensions)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,7 @@ install(FILES
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libcmark-gfm.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 install(EXPORT cmark-gfm
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cmark-gfm)
 
 export(TARGETS libcmark-gfm
   FILE ${CMAKE_CURRENT_BINARY_DIR}/cmarkTargets.cmake)


### PR DESCRIPTION
Enable wiring up builds with the staged image of cmark. The unified build no longer tries to use custom build handling and instead prefers the standard CMake usage.