### PR TITLE
feat: add partial support for WASI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ include(FindAsan)
 if(CMARK_THREADING)
   set(THREADS_PREFER_PTHREAD_FLAG YES)
   include(FindThreads)
-  add_compile_definitions(CMARK_THREADING)
 endif()
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,8 @@ endif()
 add_compile_definitions($<$<CONFIG:Debug>:CMARK_DEBUG_NODES>)
 # FIXME(compnerd) why do we not use `!defined(NDEBUG)`?
 add_compile_definitions($<$<CONFIG:Debug>:DEBUG>)
+# Use CMake's generated headers instead of the Swift package prebuilt ones
+add_compile_definitions(CMARK_USE_CMAKE_HEADERS)
 
 add_compile_options($<$<AND:$<CONFIG:PROFILE>,$<COMPILE_LANGUAGE:C>>:-pg>)
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,12 +11,9 @@ import PackageDescription
     // link time.
     let cSettings: [CSetting] = [
         .define("CMARK_GFM_STATIC_DEFINE", .when(platforms: [.windows])),
-        .define("CMARK_THREADING"),
     ]
 #else
-    let cSettings: [CSetting] = [
-        .define("CMARK_THREADING"),
-    ]
+    let cSettings: [CSetting] = []
 #endif
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
           exclude: [
             "scanners.re",
             "libcmark-gfm.pc.in",
+            "config.h.in",
             "CMakeLists.txt",
           ],
           cSettings: cSettings

--- a/api_test/harness.c
+++ b/api_test/harness.c
@@ -54,7 +54,7 @@ void INT_EQ(test_batch_runner *runner, int got, int expected, const char *msg,
   }
 }
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__wasi__)
 #include <unistd.h>
 
 static char *write_tmp(char const *header, char const *data) {
@@ -79,7 +79,7 @@ void STR_EQ(test_batch_runner *runner, const char *got, const char *expected,
   va_end(ap);
 
   if (!cond) {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__wasi__)
     char *got_fn = write_tmp("actual\n", got);
     char *expected_fn = write_tmp("expected\n", expected);
     char buf[1024];

--- a/bin/main.c
+++ b/bin/main.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "cmark-gfm-extension_api.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libcmark-gfm.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/libcmark-gfm.pc @ONLY)
 
@@ -68,6 +71,7 @@ install(FILES
   include/chunk.h
   include/cmark_ctype.h
   include/cmark-gfm.h
+  include/cmark-gfm_config.h
   include/cmark-gfm-extension_api.h
   include/cmark-gfm_version.h
   include/export.h

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -13,6 +13,7 @@
 
 #include "cmark_ctype.h"
 #include "syntax_extension.h"
+#include "cmark-gfm_config.h"
 #include "parser.h"
 #include "cmark-gfm.h"
 #include "node.h"

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark_ctype.h"
 #include "buffer.h"
 

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "buffer.h"

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,12 @@
+#ifndef CMARK_CONFIG_H
+#define CMARK_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#cmakedefine CMARK_THREADING
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#cmakedefine CMARK_THREADING
+#cmakedefine01 CMARK_THREADING
 
 #ifdef __cplusplus
 }

--- a/src/html.c
+++ b/src/html.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "cmark_ctype.h"
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "houdini.h"
 #include "scanners.h"

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <limits.h>
 #include <stdint.h>
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 
 #ifdef __cplusplus

--- a/src/include/cmark-gfm_config.h
+++ b/src/include/cmark-gfm_config.h
@@ -1,0 +1,21 @@
+#ifndef CMARK_CONFIG_H
+#define CMARK_CONFIG_H
+
+#ifdef CMARK_USE_CMAKE_HEADERS
+// if the CMake config header exists, use that instead of this Swift package prebuilt one
+// we need to undefine the header guard, since config.h uses the same one
+#undef CMARK_CONFIG_H
+#include "config.h"
+#else
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* not CMARK_USE_CMAKE_HEADERS */
+
+#endif /* not CMARK_CONFIG_H */

--- a/src/include/cmark-gfm_config.h
+++ b/src/include/cmark-gfm_config.h
@@ -12,6 +12,8 @@
 extern "C" {
 #endif
 
+#define CMARK_THREADING
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/cmark-gfm_config.h
+++ b/src/include/cmark-gfm_config.h
@@ -12,7 +12,13 @@
 extern "C" {
 #endif
 
-#define CMARK_THREADING
+#ifndef CMARK_THREADING
+#if defined(__wasi__) && !defined(_REENTRANT)
+#define CMARK_THREADING 0
+#else
+#define CMARK_THREADING 1
+#endif
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/include/houdini.h
+++ b/src/include/houdini.h
@@ -2,7 +2,7 @@
 #define CMARK_HOUDINI_H
 
 #include <stdint.h>
-
+#include "cmark-gfm_config.h"
 #include "buffer.h"
 
 #ifdef __cplusplus

--- a/src/include/inlines.h
+++ b/src/include/inlines.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "cmark-gfm_config.h"
 #include "references.h"
 
 #ifdef __cplusplus

--- a/src/include/module.modulemap
+++ b/src/include/module.modulemap
@@ -1,5 +1,6 @@
 module cmark_gfm {
     header "cmark-gfm.h"
+    header "cmark-gfm_config.h"
     header "cmark-gfm-extension_api.h"
     header "buffer.h"
     header "chunk.h"

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -3,9 +3,15 @@
 
 #include <stdbool.h>
 
+#ifndef CMARK_THREADING
+#if !defined(__wasi__) || defined(_REENTRANT)
+#define CMARK_THREADING
+#endif
+#endif
+
 #ifdef CMARK_THREADING
 
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__wasi__)
 #include <unistd.h>
 #endif
 

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -1,6 +1,8 @@
 #ifndef CMARK_MUTEX_H
 #define CMARK_MUTEX_H
 
+#include "cmark-gfm_config.h"
+
 #include <stdbool.h>
 
 #ifndef CMARK_THREADING

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -5,13 +5,7 @@
 
 #include <stdbool.h>
 
-#ifndef CMARK_THREADING
-#if !defined(__wasi__) || defined(_REENTRANT)
-#define CMARK_THREADING
-#endif
-#endif
-
-#ifdef CMARK_THREADING
+#if CMARK_THREADING
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__wasi__)
 #include <unistd.h>

--- a/src/include/syntax_extension.h
+++ b/src/include/syntax_extension.h
@@ -3,6 +3,7 @@
 
 #include "cmark-gfm.h"
 #include "cmark-gfm-extension_api.h"
+#include "cmark-gfm_config.h"
 
 #include <stdbool.h>
 

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "cmark_ctype.h"
+#include "cmark-gfm_config.h"
 #include "node.h"
 #include "parser.h"
 #include "references.h"

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "cmark-gfm_config.h"
 #include "node.h"
 #include "cmark-gfm.h"
 #include "iterator.h"

--- a/src/latex.c
+++ b/src/latex.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "buffer.h"

--- a/src/man.c
+++ b/src/man.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "buffer.h"

--- a/src/node.c
+++ b/src/node.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "mutex.h"
 #include "node.h"
 #include "syntax_extension.h"

--- a/src/registry.c
+++ b/src/registry.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "mutex.h"
 #include "syntax_extension.h"

--- a/src/xml.c
+++ b/src/xml.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "buffer.h"


### PR DESCRIPTION
## Description

This change allows building the `cmark-gfm` target for both `wasm32-unknown-wasi` and `wasm32-unknown-wasip1-threads`. The other targets are not tested.

## The current problem

The differences between two target triples are as follows:

- `wasm32-unknown-wasi`
  - C
    - can import `unistd.h`
    - has `__wasi__`
    - does not have `__unix__`
    - **does not have `_REENTRANT`**
    - **does not have `_POSIX_THREADS`**
    - **does not support pthreads API at all**
  - Swift
    - can use `#if os(WASI)`
  - SwiftPM
    - `BuildSettingsCondition`'s `Platform` is `.wasi`
- `wasm32-unknown-wasip1-threads`
  - C
    - can import `unistd.h`
    - has `__wasi__`
    - does not have `__unix__`
    - **has `_REENTRANT` (defined in wasi-libc)**
    - **has `_POSIX_THREADS` (defined in wasi-libc)**
    - **supports a subset of pthreads API**
  - Swift
    - can use `#if os(WASI)`
  - SwiftPM
    - `BuildSettingsCondition`'s `Platform` is `.wasi`

Therefore, `CMARK_THREADING` must not be defined when building for `wasm32-unknown-wasi`, but must be defined when building for `wasm32-unknown-wasip1-threads`.

However, when building with CMake, it is controllable, but when building with SwiftPM, [`CMARK_THREADING` is always defined](https://github.com/swiftlang/swift-cmark/blob/b022b08312decdc46585e0b3440d97f6f22ef703/Package.swift#L18).

## Proposed solution

- Building with CMake and Make
  - Current
    - When running with `-DCMARK_THREADING=OFF` (default), `CMARK_THREADING` will not be defined in the C compiler.
    - When running with `-DCMARK_THREADING=ON`, `CMARK_THREADING` will be defined in the C compiler.
  - New
    - When running with `-DCMARK_THREADING=OFF` (default), `CMARK_THREADING` will be defined in `config.h` and be `0`.
    - When running with `-DCMARK_THREADING=ON`, `CMARK_THREADING` will be defined in `config.h` and be `1`.
- Building with SwiftPM
  - Current: `.define("CMARK_THREADING")` will be added in `Package.swift`.
  - New: `.define("CMARK_THREADING")` will not be added in `Package.swift`. (reverting aef4761a7878a437b981251fc31d0a7b7392de12)
    - Instead, `CMARK_THREADING` will automatically be defined as one of the following values in `src/include/cmark-gfm_config.h`.
      - `0` if building for targets that do not support threading (e.g. `wasm32-unknown-wasi`)
      - `1` if building for the other targets including `wasm32-unknown-wasip1-threads`

I reverted 6f648763b260b38ea6bce7fd0dfa24ea2fa9e4ef because I needed `src/config.h.in` and `src/include/cmark-gfm_config.h`.

## Checks

I've tested this PR (415c3ac674340254a9c703b4860e46aa01159aed) by the following ways on Linux.

```
Linux Raspberry-beetle 6.12.21-v8-16k+ #1868 SMP PREEMPT Mon Mar 31 17:10:57 BST 2025 aarch64 GNU/Linux
```

### Building with SwiftPM

[swift-DEVELOPMENT-SNAPSHOT-2025-03-28-a](https://github.com/apple/swift/releases/tag/swift-DEVELOPMENT-SNAPSHOT-2025-03-28-a):

1. Install swiftly 1.0.0
2. `swiftly install main-snapshot-2025-03-28`
3. `swiftly use main-snapshot-2025-03-28`
4. `swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-28-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-28-a-wasm32-unknown-wasi.artifactbundle.zip --checksum c2ab6d3360591d14af05e2bcfcc1ba970f2c3c6862e70b47f36075f846921287` ([instructions](https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-28-a))
5. `swift build --swift-sdk wasm32-unknown-wasi --target cmark-gfm`
6. `swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-28-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-28-a-wasm32-unknown-wasip1-threads.artifactbundle.zip --checksum 020c7a34a9b5da144f2edbe0b4d4116729ddf6a484674e11357b3fc45b226e86` ([instructions](https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-28-a))
7. `swift build --swift-sdk wasm32-unknown-wasip1-threads --target cmark-gfm`
8. `swift build`

```console
$ swift --version
Swift version 6.2-dev (LLVM 6f817b270d9dadc, Swift d36b06747a54689)
Target: aarch64-unknown-linux-gnu
Build config: +assertions
$ swift build --swift-sdk wasm32-unknown-wasi --target cmark-gfm
Building for debugging...
[27/27] Compiling cmark-gfm scanners.c
Build of target: 'cmark-gfm' complete! (2.99s)
$ swift build --swift-sdk wasm32-unknown-wasip1-threads --target cmark-gfm
Building for debugging...
[27/27] Compiling cmark-gfm scanners.c
Build of target: 'cmark-gfm' complete! (2.98s)
$ swift build
Building for debugging...
[42/42] Linking api_test
Build complete! (4.55s)
```

### Building with CMake and Make

<details><summary>-DCMARK_THREADING=ON</summary>

```console
$ cmake -S . -B build -DCMARK_THREADING=ON
26ms 
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test HAVE_FLAG_ADDRESS_SANITIZER
-- Performing Test HAVE_FLAG_ADDRESS_SANITIZER - Failed
-- Performing Test HAVE_FLAG_SANITIZE_ADDRESS
-- Performing Test HAVE_FLAG_SANITIZE_ADDRESS - Success
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Checking _FILE_OFFSET_BITS for large files
-- Checking _FILE_OFFSET_BITS for large files - not needed
-- Found Python3: /usr/bin/python3 (found version "3.11.2") found components: Interpreter 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/kebo/swift-cmark/build
$ cmake --build build
[  2%] Building C object src/CMakeFiles/libcmark-gfm.dir/arena.c.o                                                                                                                       
In file included from /home/kebo/swift-cmark/src/arena.c:6:                                                                                                                              
/home/kebo/swift-cmark/src/include/mutex.h:24:24: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]                                                             
   24 | CMARK_DEFINE_ONCE(NAME); \                                                                                                                                                       
      |                        ^                                                                                                                                                         
/home/kebo/swift-cmark/src/arena.c:8:1: note: in expansion of macro ‘CMARK_DEFINE_LOCK’                                                                                                  
    8 | CMARK_DEFINE_LOCK(arena)                                                                                                                                                         
      | ^~~~~~~~~~~~~~~~~                                                                                                                                                                
[  4%] Building C object src/CMakeFiles/libcmark-gfm.dir/blocks.c.o                                                                                                                      
[  7%] Building C object src/CMakeFiles/libcmark-gfm.dir/buffer.c.o                                                                                                                      
[  9%] Building C object src/CMakeFiles/libcmark-gfm.dir/cmark.c.o                                                                                                                       
[ 11%] Building C object src/CMakeFiles/libcmark-gfm.dir/cmark_ctype.c.o                                                                                                                 
[ 14%] Building C object src/CMakeFiles/libcmark-gfm.dir/commonmark.c.o                                                                                                                  
[ 16%] Building C object src/CMakeFiles/libcmark-gfm.dir/footnotes.c.o                                                                                                                   
[ 19%] Building C object src/CMakeFiles/libcmark-gfm.dir/houdini_href_e.c.o                                                                                                              
[ 21%] Building C object src/CMakeFiles/libcmark-gfm.dir/houdini_html_e.c.o                                                                                                              
[ 23%] Building C object src/CMakeFiles/libcmark-gfm.dir/houdini_html_u.c.o                                                                                                              
[ 26%] Building C object src/CMakeFiles/libcmark-gfm.dir/html.c.o                                                                                                                        
[ 28%] Building C object src/CMakeFiles/libcmark-gfm.dir/inlines.c.o                                                                                                                     
[ 30%] Building C object src/CMakeFiles/libcmark-gfm.dir/iterator.c.o                                                                                                                    
[ 33%] Building C object src/CMakeFiles/libcmark-gfm.dir/latex.c.o                                                                                                                       
[ 35%] Building C object src/CMakeFiles/libcmark-gfm.dir/linked_list.c.o                                                                                                                 
[ 38%] Building C object src/CMakeFiles/libcmark-gfm.dir/man.c.o                                                                                                                         
[ 40%] Building C object src/CMakeFiles/libcmark-gfm.dir/map.c.o
[ 42%] Building C object src/CMakeFiles/libcmark-gfm.dir/node.c.o
In file included from /home/kebo/swift-cmark/src/node.c:6:
/home/kebo/swift-cmark/src/include/mutex.h:24:24: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
   24 | CMARK_DEFINE_ONCE(NAME); \
      |                        ^
/home/kebo/swift-cmark/src/node.c:10:1: note: in expansion of macro ‘CMARK_DEFINE_LOCK’
   10 | CMARK_DEFINE_LOCK(nextflag)
      | ^~~~~~~~~~~~~~~~~
/home/kebo/swift-cmark/src/include/mutex.h:24:24: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
   24 | CMARK_DEFINE_ONCE(NAME); \
      |                        ^
/home/kebo/swift-cmark/src/node.c:11:1: note: in expansion of macro ‘CMARK_DEFINE_LOCK’
   11 | CMARK_DEFINE_LOCK(safety)
      | ^~~~~~~~~~~~~~~~~
[ 45%] Building C object src/CMakeFiles/libcmark-gfm.dir/plaintext.c.o
[ 47%] Building C object src/CMakeFiles/libcmark-gfm.dir/plugin.c.o
[ 50%] Building C object src/CMakeFiles/libcmark-gfm.dir/references.c.o
[ 52%] Building C object src/CMakeFiles/libcmark-gfm.dir/registry.c.o
In file included from /home/kebo/swift-cmark/src/registry.c:7:
/home/kebo/swift-cmark/src/include/mutex.h:24:24: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
   24 | CMARK_DEFINE_ONCE(NAME); \
      |                        ^
/home/kebo/swift-cmark/src/registry.c:16:1: note: in expansion of macro ‘CMARK_DEFINE_LOCK’
   16 | CMARK_DEFINE_LOCK(extensions);
      | ^~~~~~~~~~~~~~~~~
/home/kebo/swift-cmark/src/registry.c:16:30: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
   16 | CMARK_DEFINE_LOCK(extensions);
      |                              ^
[ 54%] Building C object src/CMakeFiles/libcmark-gfm.dir/render.c.o                                                                                                                      
[ 57%] Building C object src/CMakeFiles/libcmark-gfm.dir/scanners.c.o
[ 59%] Building C object src/CMakeFiles/libcmark-gfm.dir/syntax_extension.c.o
[ 61%] Building C object src/CMakeFiles/libcmark-gfm.dir/utf8.c.o                      
[ 64%] Building C object src/CMakeFiles/libcmark-gfm.dir/xml.c.o                                                                                                                         
[ 66%] Linking C static library libcmark-gfm.a                                                                                                                                           
[ 66%] Built target libcmark-gfm                                                                                                                                                         
[ 69%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/autolink.c.o
[ 71%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/core-extensions.c.o
/home/kebo/swift-cmark/extensions/core-extensions.c:22:30: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
   22 | CMARK_DEFINE_ONCE(registered);                                                      
      |                              ^                                                      
[ 73%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/ext_scanners.c.o
[ 76%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/strikethrough.c.o 
[ 78%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/table.c.o        
[ 80%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/tagfilter.c.o
[ 83%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/tasklist.c.o     
[ 85%] Linking C static library libcmark-gfm-extensions.a                                                                                                                                
[ 85%] Built target libcmark-gfm-extensions                                                 
[ 88%] Building C object src/CMakeFiles/cmark-gfm.dir/__/bin/main.c.o
[ 90%] Linking C executable cmark-gfm                                                       
[ 90%] Built target cmark-gfm                                                               
[ 92%] Building CXX object api_test/CMakeFiles/api_test.dir/cplusplus.cpp.o                                                                                                              
[ 95%] Building C object api_test/CMakeFiles/api_test.dir/harness.c.o                                                                                                                    
[ 97%] Building C object api_test/CMakeFiles/api_test.dir/main.c.o
/home/kebo/swift-cmark/api_test/main.c: In function ‘reentrant_parse_inline_ext’:
/home/kebo/swift-cmark/api_test/main.c:1374:32: warning: ISO C forbids conversion of object pointer to function pointer type [-Wpedantic]
 1374 |     reentrant_call_func func = (reentrant_call_func)priv;                     
      |                                ^                                                    
/home/kebo/swift-cmark/api_test/main.c: In function ‘parser_interrupt’:                     
/home/kebo/swift-cmark/api_test/main.c:1398:46: warning: ISO C forbids conversion of function pointer to object pointer type [-Wpedantic]
 1398 |   cmark_syntax_extension_set_private(my_ext, (void *)&run_inner_parser, NULL);                                                                                                   
      |                                              ^
[100%] Linking CXX executable api_test
[100%] Built target api_test
$ cat build/src/config.h
#ifndef CMARK_CONFIG_H
#define CMARK_CONFIG_H

#ifdef __cplusplus
extern "C" {
#endif

#define CMARK_THREADING 1

#ifdef __cplusplus
}
#endif

#endif
```

</details>

<details><summary>-DCMARK_THREADING=OFF</summary>

```console
$ cmake -S . -B build -DCMARK_THREADING=OFF
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test HAVE_FLAG_ADDRESS_SANITIZER
-- Performing Test HAVE_FLAG_ADDRESS_SANITIZER - Failed
-- Performing Test HAVE_FLAG_SANITIZE_ADDRESS
-- Performing Test HAVE_FLAG_SANITIZE_ADDRESS - Success
-- Checking _FILE_OFFSET_BITS for large files
-- Checking _FILE_OFFSET_BITS for large files - not needed
-- Found Python3: /usr/bin/python3 (found version "3.11.2") found components: Interpreter 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/kebo/swift-cmark/build
$ cmake --build build
[  2%] Building C object src/CMakeFiles/libcmark-gfm.dir/arena.c.o
[  4%] Building C object src/CMakeFiles/libcmark-gfm.dir/blocks.c.o
[  7%] Building C object src/CMakeFiles/libcmark-gfm.dir/buffer.c.o
[  9%] Building C object src/CMakeFiles/libcmark-gfm.dir/cmark.c.o
[ 11%] Building C object src/CMakeFiles/libcmark-gfm.dir/cmark_ctype.c.o
[ 14%] Building C object src/CMakeFiles/libcmark-gfm.dir/commonmark.c.o
[ 16%] Building C object src/CMakeFiles/libcmark-gfm.dir/footnotes.c.o
[ 19%] Building C object src/CMakeFiles/libcmark-gfm.dir/houdini_href_e.c.o
[ 21%] Building C object src/CMakeFiles/libcmark-gfm.dir/houdini_html_e.c.o
[ 23%] Building C object src/CMakeFiles/libcmark-gfm.dir/houdini_html_u.c.o
[ 26%] Building C object src/CMakeFiles/libcmark-gfm.dir/html.c.o
[ 28%] Building C object src/CMakeFiles/libcmark-gfm.dir/inlines.c.o
[ 30%] Building C object src/CMakeFiles/libcmark-gfm.dir/iterator.c.o
[ 33%] Building C object src/CMakeFiles/libcmark-gfm.dir/latex.c.o
[ 35%] Building C object src/CMakeFiles/libcmark-gfm.dir/linked_list.c.o
[ 38%] Building C object src/CMakeFiles/libcmark-gfm.dir/man.c.o
[ 40%] Building C object src/CMakeFiles/libcmark-gfm.dir/map.c.o
[ 42%] Building C object src/CMakeFiles/libcmark-gfm.dir/node.c.o
[ 45%] Building C object src/CMakeFiles/libcmark-gfm.dir/plaintext.c.o
[ 47%] Building C object src/CMakeFiles/libcmark-gfm.dir/plugin.c.o
[ 50%] Building C object src/CMakeFiles/libcmark-gfm.dir/references.c.o
[ 52%] Building C object src/CMakeFiles/libcmark-gfm.dir/registry.c.o
/home/kebo/swift-cmark/src/registry.c:16:30: warning: ISO C does not allow extra â;â outside of a function [-Wpedantic]
   16 | CMARK_DEFINE_LOCK(extensions);
      |                              ^
[ 54%] Building C object src/CMakeFiles/libcmark-gfm.dir/render.c.o
[ 57%] Building C object src/CMakeFiles/libcmark-gfm.dir/scanners.c.o
[ 59%] Building C object src/CMakeFiles/libcmark-gfm.dir/syntax_extension.c.o
[ 61%] Building C object src/CMakeFiles/libcmark-gfm.dir/utf8.c.o
[ 64%] Building C object src/CMakeFiles/libcmark-gfm.dir/xml.c.o
[ 66%] Linking C static library libcmark-gfm.a
[ 66%] Built target libcmark-gfm
[ 69%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/autolink.c.o
[ 71%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/core-extensions.c.o
/home/kebo/swift-cmark/extensions/core-extensions.c:22:30: warning: ISO C does not allow extra â;â outside of a function [-Wpedantic]
   22 | CMARK_DEFINE_ONCE(registered);
      |                              ^
[ 73%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/ext_scanners.c.o
[ 76%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/strikethrough.c.o
[ 78%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/table.c.o
[ 80%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/tagfilter.c.o
[ 83%] Building C object extensions/CMakeFiles/libcmark-gfm-extensions.dir/tasklist.c.o
[ 85%] Linking C static library libcmark-gfm-extensions.a
[ 85%] Built target libcmark-gfm-extensions
[ 88%] Building C object src/CMakeFiles/cmark-gfm.dir/__/bin/main.c.o
[ 90%] Linking C executable cmark-gfm
[ 90%] Built target cmark-gfm
[ 92%] Building CXX object api_test/CMakeFiles/api_test.dir/cplusplus.cpp.o
[ 95%] Building C object api_test/CMakeFiles/api_test.dir/harness.c.o
[ 97%] Building C object api_test/CMakeFiles/api_test.dir/main.c.o
/home/kebo/swift-cmark/api_test/main.c: In function âreentrant_parse_inline_extâ:
/home/kebo/swift-cmark/api_test/main.c:1374:32: warning: ISO C forbids conversion of object pointer to function pointer type [-Wpedantic]
 1374 |     reentrant_call_func func = (reentrant_call_func)priv;
      |                                ^
/home/kebo/swift-cmark/api_test/main.c: In function âparser_interruptâ:
/home/kebo/swift-cmark/api_test/main.c:1398:46: warning: ISO C forbids conversion of function pointer to object pointer type [-Wpedantic]
 1398 |   cmark_syntax_extension_set_private(my_ext, (void *)&run_inner_parser, NULL);
      |                                              ^
[100%] Linking CXX executable api_test
[100%] Built target api_test
$ cat build/src/config.h
#ifndef CMARK_CONFIG_H
#define CMARK_CONFIG_H

#ifdef __cplusplus
extern "C" {
#endif

#define CMARK_THREADING 0

#ifdef __cplusplus
}
#endif

#endif
```

</details>

### Building as an external dependency with SwiftPM

This CI workflow builds swift-format's executable and test executable for `wasm32-unknown-wasi`. swift-format depends on swift-cmark, and the following one is using this PR's branch. The test executable runs on a WebAssembly runtime (wasmtime). As you can see, all tests cases have passed.

~~https://github.com/kkebo/swift-format/actions/runs/11669491583~~
https://github.com/kkebo/swift-format/actions/runs/14224215545