### PR TITLE
Expose list marker characters for unordered lists

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -107,6 +107,8 @@ static void accessors(test_batch_runner *runner) {
          "get_list_type bullet");
   INT_EQ(runner, cmark_node_get_list_tight(bullet_list), 1,
          "get_list_tight tight");
+  INT_EQ(runner, cmark_node_get_list_marker(bullet_list), CMARK_ASTERISK_LIST_MARKER,
+         "get_list_marker asterisk");
 
   cmark_node *ordered_list = cmark_node_next(bullet_list);
   INT_EQ(runner, cmark_node_get_list_type(ordered_list), CMARK_ORDERED_LIST,
@@ -146,6 +148,7 @@ static void accessors(test_batch_runner *runner) {
 
   OK(runner, cmark_node_set_heading_level(heading, 3), "set_heading_level");
 
+  OK(runner, cmark_node_set_list_marker(bullet_list, CMARK_PLUS_LIST_MARKER), "set_list_marker plus");
   OK(runner, cmark_node_set_list_type(bullet_list, CMARK_ORDERED_LIST),
      "set_list_type ordered");
   OK(runner, cmark_node_set_list_delim(bullet_list, CMARK_PAREN_DELIM),
@@ -211,6 +214,7 @@ static void accessors(test_batch_runner *runner) {
          "get_list_type error");
   INT_EQ(runner, cmark_node_get_list_start(code), 0, "get_list_start error");
   INT_EQ(runner, cmark_node_get_list_tight(fenced), 0, "get_list_tight error");
+  INT_EQ(runner, cmark_node_get_list_marker(heading), CMARK_NO_LIST_MARKER, "get_list_marker error");
   OK(runner, cmark_node_get_literal(ordered_list) == NULL, "get_literal error");
   OK(runner, cmark_node_get_fence_info(paragraph) == NULL,
      "get_fence_info error");
@@ -225,6 +229,7 @@ static void accessors(test_batch_runner *runner) {
      "set_list_type error");
   OK(runner, !cmark_node_set_list_start(code, 3), "set_list_start error");
   OK(runner, !cmark_node_set_list_tight(fenced, 0), "set_list_tight error");
+  OK(runner, !cmark_node_set_list_marker(heading, CMARK_PLUS_LIST_MARKER), "set_list_marker error");
   OK(runner, !cmark_node_set_literal(ordered_list, "content\n"),
      "set_literal error");
   OK(runner, !cmark_node_set_fence_info(paragraph, "lang"),
@@ -240,6 +245,8 @@ static void accessors(test_batch_runner *runner) {
      "set_list_type invalid");
   OK(runner, !cmark_node_set_list_start(bullet_list, -1),
      "set_list_start negative");
+  OK(runner, !cmark_node_set_list_marker(bullet_list, CMARK_NO_LIST_MARKER),
+     "set_list_marker invalid");
 
   cmark_node_free(doc);
 }

--- a/src/include/cmark-gfm.h
+++ b/src/include/cmark-gfm.h
@@ -90,6 +90,13 @@ typedef enum {
   CMARK_PAREN_DELIM
 } cmark_delim_type;
 
+typedef enum {
+  CMARK_NO_LIST_MARKER,
+  CMARK_HYPHEN_LIST_MARKER,
+  CMARK_PLUS_LIST_MARKER,
+  CMARK_ASTERISK_LIST_MARKER
+} cmark_list_marker_type;
+
 typedef struct cmark_node cmark_node;
 typedef struct cmark_parser cmark_parser;
 typedef struct cmark_iter cmark_iter;
@@ -394,6 +401,16 @@ CMARK_GFM_EXPORT cmark_list_type cmark_node_get_list_type(cmark_node *node);
  */
 CMARK_GFM_EXPORT int cmark_node_set_list_type(cmark_node *node,
                                           cmark_list_type type);
+
+/** Returns the list marker of 'node', or `CMARK_NO_LIST_MARKER` if 'node'
+ * is not a list.
+ */
+CMARK_GFM_EXPORT cmark_list_marker_type cmark_node_get_list_marker(cmark_node *node);
+
+/** Sets the list marker of 'node', returning 1 on success and 0 on error.
+ */
+CMARK_GFM_EXPORT int cmark_node_set_list_marker(cmark_node *node,
+                                                cmark_list_marker_type listMarker);
 
 /** Returns the list delimiter type of 'node', or `CMARK_NO_DELIM` if 'node'
  * is not a list.
@@ -865,6 +882,9 @@ const char *cmark_version_string(void);
 #define ORDERED_LIST CMARK_ORDERED_LIST
 #define PERIOD_DELIM CMARK_PERIOD_DELIM
 #define PAREN_DELIM CMARK_PAREN_DELIM
+#define HYPHEN_LIST_MARKER CMARK_HYPHEN_LIST_MARKER
+#define PLUS_LIST_MARKER CMARK_PLUS_LIST_MARKER
+#define ASTERISK_LIST_MARKER CMARK_ASTERISK_LIST_MARKER
 #endif
 
 typedef int32_t bufsize_t;

--- a/src/node.c
+++ b/src/node.c
@@ -530,6 +530,43 @@ int cmark_node_set_list_type(cmark_node *node, cmark_list_type type) {
   }
 }
 
+cmark_list_marker_type cmark_node_get_list_marker(cmark_node *node) {
+  if (cmark_node_get_list_type(node) != CMARK_BULLET_LIST) {
+    return CMARK_NO_LIST_MARKER;
+  }
+  
+  switch (node->as.list.bullet_char) {
+    case '-': return CMARK_HYPHEN_LIST_MARKER;
+    case '+': return CMARK_PLUS_LIST_MARKER;
+    case '*': return CMARK_ASTERISK_LIST_MARKER;
+    default: return CMARK_NO_LIST_MARKER;
+  }
+}
+
+int cmark_node_set_list_marker(cmark_node *node, cmark_list_marker_type listMarker) {
+  if (!(listMarker == CMARK_HYPHEN_LIST_MARKER || listMarker == CMARK_PLUS_LIST_MARKER || listMarker == CMARK_ASTERISK_LIST_MARKER)) {
+    return 0;
+  }
+  
+  if (cmark_node_get_list_type(node) != CMARK_BULLET_LIST) {
+    return 0;
+  }
+  
+  switch (listMarker) {
+    case CMARK_HYPHEN_LIST_MARKER:
+      node->as.list.bullet_char = '-';
+      return 1;
+    case CMARK_PLUS_LIST_MARKER:
+      node->as.list.bullet_char = '+';
+      return 1;
+    case CMARK_ASTERISK_LIST_MARKER:
+      node->as.list.bullet_char = '*';
+      return 1;
+    default:
+      return 0;
+  }
+}
+
 cmark_delim_type cmark_node_get_list_delim(cmark_node *node) {
   if (node == NULL) {
     return CMARK_NO_DELIM;


### PR DESCRIPTION
This PR adds new cmark C APIs that expose the list marker characters for unordered lists (`-`, `*`, or `+`)