### PR TITLE
Move `extensions/include/cmark-gfm-core-extensions.h` cpp includes out of extern "C" block

### DIFF
--- a/extensions/include/cmark-gfm-core-extensions.h
+++ b/extensions/include/cmark-gfm-core-extensions.h
@@ -1,15 +1,15 @@
 #ifndef CMARK_GFM_CORE_EXTENSIONS_H
 #define CMARK_GFM_CORE_EXTENSIONS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "cmark-gfm-extension_api.h"
 #include "export.h"
 
 #include <stdbool.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 CMARK_GFM_EXPORT
 void cmark_gfm_core_extensions_ensure_registered(void);

--- a/src/include/module.modulemap
+++ b/src/include/module.modulemap
@@ -5,6 +5,7 @@ module cmark_gfm {
     header "buffer.h"
     header "chunk.h"
     header "cmark_ctype.h"
+    header "export.h"
     header "footnotes.h"
     header "houdini.h"
     header "html.h"


### PR DESCRIPTION
When the `extern "C"` block is emitted, the compiler complains about these includes.