### PR TITLE
[6.2] fix build failures for WASI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ include(FindAsan)
 if(CMARK_THREADING)
   set(THREADS_PREFER_PTHREAD_FLAG YES)
   include(FindThreads)
-  add_compile_definitions(CMARK_THREADING)
 endif()
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,8 @@ endif()
 add_compile_definitions($<$<CONFIG:Debug>:CMARK_DEBUG_NODES>)
 # FIXME(compnerd) why do we not use `!defined(NDEBUG)`?
 add_compile_definitions($<$<CONFIG:Debug>:DEBUG>)
+# Use CMake's generated headers instead of the Swift package prebuilt ones
+add_compile_definitions(CMARK_USE_CMAKE_HEADERS)
 
 add_compile_options($<$<AND:$<CONFIG:PROFILE>,$<COMPILE_LANGUAGE:C>>:-pg>)
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,12 +11,9 @@ import PackageDescription
     // link time.
     let cSettings: [CSetting] = [
         .define("CMARK_GFM_STATIC_DEFINE", .when(platforms: [.windows])),
-        .define("CMARK_THREADING"),
     ]
 #else
-    let cSettings: [CSetting] = [
-        .define("CMARK_THREADING"),
-    ]
+    let cSettings: [CSetting] = []
 #endif
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
           exclude: [
             "scanners.re",
             "libcmark-gfm.pc.in",
+            "config.h.in",
             "CMakeLists.txt",
           ],
           cSettings: cSettings

--- a/api_test/harness.c
+++ b/api_test/harness.c
@@ -54,7 +54,7 @@ void INT_EQ(test_batch_runner *runner, int got, int expected, const char *msg,
   }
 }
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__wasi__)
 #include <unistd.h>
 
 static char *write_tmp(char const *header, char const *data) {
@@ -79,7 +79,7 @@ void STR_EQ(test_batch_runner *runner, const char *got, const char *expected,
   va_end(ap);
 
   if (!cond) {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__wasi__)
     char *got_fn = write_tmp("actual\n", got);
     char *expected_fn = write_tmp("expected\n", expected);
     char buf[1024];

--- a/bin/main.c
+++ b/bin/main.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "cmark-gfm-extension_api.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libcmark-gfm.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/libcmark-gfm.pc @ONLY)
 
@@ -68,6 +71,7 @@ install(FILES
   include/chunk.h
   include/cmark_ctype.h
   include/cmark-gfm.h
+  include/cmark-gfm_config.h
   include/cmark-gfm-extension_api.h
   include/cmark-gfm_version.h
   include/export.h

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -13,6 +13,7 @@
 
 #include "cmark_ctype.h"
 #include "syntax_extension.h"
+#include "cmark-gfm_config.h"
 #include "parser.h"
 #include "cmark-gfm.h"
 #include "node.h"

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark_ctype.h"
 #include "buffer.h"
 

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "buffer.h"

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,12 @@
+#ifndef CMARK_CONFIG_H
+#define CMARK_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#cmakedefine CMARK_THREADING
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#cmakedefine CMARK_THREADING
+#cmakedefine01 CMARK_THREADING
 
 #ifdef __cplusplus
 }

--- a/src/html.c
+++ b/src/html.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "cmark_ctype.h"
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "houdini.h"
 #include "scanners.h"

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <limits.h>
 #include <stdint.h>
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 
 #ifdef __cplusplus

--- a/src/include/cmark-gfm_config.h
+++ b/src/include/cmark-gfm_config.h
@@ -1,0 +1,21 @@
+#ifndef CMARK_CONFIG_H
+#define CMARK_CONFIG_H
+
+#ifdef CMARK_USE_CMAKE_HEADERS
+// if the CMake config header exists, use that instead of this Swift package prebuilt one
+// we need to undefine the header guard, since config.h uses the same one
+#undef CMARK_CONFIG_H
+#include "config.h"
+#else
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* not CMARK_USE_CMAKE_HEADERS */
+
+#endif /* not CMARK_CONFIG_H */

--- a/src/include/cmark-gfm_config.h
+++ b/src/include/cmark-gfm_config.h
@@ -12,6 +12,8 @@
 extern "C" {
 #endif
 
+#define CMARK_THREADING
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/cmark-gfm_config.h
+++ b/src/include/cmark-gfm_config.h
@@ -12,7 +12,13 @@
 extern "C" {
 #endif
 
-#define CMARK_THREADING
+#ifndef CMARK_THREADING
+#if defined(__wasi__) && !defined(_REENTRANT)
+#define CMARK_THREADING 0
+#else
+#define CMARK_THREADING 1
+#endif
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/include/houdini.h
+++ b/src/include/houdini.h
@@ -2,7 +2,7 @@
 #define CMARK_HOUDINI_H
 
 #include <stdint.h>
-
+#include "cmark-gfm_config.h"
 #include "buffer.h"
 
 #ifdef __cplusplus

--- a/src/include/inlines.h
+++ b/src/include/inlines.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "cmark-gfm_config.h"
 #include "references.h"
 
 #ifdef __cplusplus

--- a/src/include/module.modulemap
+++ b/src/include/module.modulemap
@@ -1,5 +1,6 @@
 module cmark_gfm {
     header "cmark-gfm.h"
+    header "cmark-gfm_config.h"
     header "cmark-gfm-extension_api.h"
     header "buffer.h"
     header "chunk.h"

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -3,9 +3,15 @@
 
 #include <stdbool.h>
 
+#ifndef CMARK_THREADING
+#if !defined(__wasi__) || defined(_REENTRANT)
+#define CMARK_THREADING
+#endif
+#endif
+
 #ifdef CMARK_THREADING
 
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__wasi__)
 #include <unistd.h>
 #endif
 

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -1,6 +1,8 @@
 #ifndef CMARK_MUTEX_H
 #define CMARK_MUTEX_H
 
+#include "cmark-gfm_config.h"
+
 #include <stdbool.h>
 
 #ifndef CMARK_THREADING

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -5,13 +5,7 @@
 
 #include <stdbool.h>
 
-#ifndef CMARK_THREADING
-#if !defined(__wasi__) || defined(_REENTRANT)
-#define CMARK_THREADING
-#endif
-#endif
-
-#ifdef CMARK_THREADING
+#if CMARK_THREADING
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__wasi__)
 #include <unistd.h>

--- a/src/include/syntax_extension.h
+++ b/src/include/syntax_extension.h
@@ -3,6 +3,7 @@
 
 #include "cmark-gfm.h"
 #include "cmark-gfm-extension_api.h"
+#include "cmark-gfm_config.h"
 
 #include <stdbool.h>
 

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "cmark_ctype.h"
+#include "cmark-gfm_config.h"
 #include "node.h"
 #include "parser.h"
 #include "references.h"

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "cmark-gfm_config.h"
 #include "node.h"
 #include "cmark-gfm.h"
 #include "iterator.h"

--- a/src/latex.c
+++ b/src/latex.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "buffer.h"

--- a/src/man.c
+++ b/src/man.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "buffer.h"

--- a/src/node.c
+++ b/src/node.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "mutex.h"
 #include "node.h"
 #include "syntax_extension.h"

--- a/src/registry.c
+++ b/src/registry.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "mutex.h"
 #include "syntax_extension.h"

--- a/src/xml.c
+++ b/src/xml.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cmark-gfm_config.h"
 #include "cmark-gfm.h"
 #include "node.h"
 #include "buffer.h"


### PR DESCRIPTION
Cherry-pick of #75, merged as cbd8eae0689857c873063f28b9a80419ec718e20

**Explanation**: This change allows building the `cmark-gfm` target for both `wasm32-unknown-wasi` and `wasm32-unknown-wasip1-threads`.
**Scope**: Limited to WASI support.
**Risk**: Low due to changes not impacting other platforms.
**Testing**: Added in `swift-format` repo, which has a transitive dependency on `swift-cmark`.
**Issue**: rdar://163652438
**Reviewer**: @QuietMisdreavus 
