### PR TITLE
fix: Unbalanced parentheses shouldn’t be parsed as links.

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -490,8 +490,9 @@ static int scan_delims(cmark_parser *parser, subject *subj, unsigned char c,
     *can_close = right_flanking &&
                  (!left_flanking || cmark_utf8proc_is_punctuation(after_char));
   } else if (c == '\'' || c == '"') {
-    *can_open = left_flanking && !right_flanking &&
-	         before_char != ']' && before_char != ')';
+    *can_open = left_flanking &&
+         (!right_flanking || before_char == '(' || before_char == '[') &&
+         before_char != ']' && before_char != ')';
     *can_close = right_flanking;
   } else {
     *can_open = left_flanking;
@@ -1118,7 +1119,7 @@ static bufsize_t manual_scan_link_url_2(cmark_chunk *input, bufsize_t offset,
     }
   }
 
-  if (i >= input->len)
+  if (i >= input->len || nb_p != 0)
     return -1;
 
   {

--- a/test/regression.txt
+++ b/test/regression.txt
@@ -237,6 +237,18 @@ Issue commonmark#526 - unescaped ( in link title
 <p>[link](url ((title))</p>
 ````````````````````````````````
 
+Issue commonmark.js#177 - Unbalanced parentheses in link URLs should not be parsed as links
+
+```````````````````````````````` example
+[link](/u(ri )
+[link](/u(ri
+)
+.
+<p>[link](/u(ri )
+[link](/u(ri
+)</p>
+````````````````````````````````
+
 Issue commonamrk#517 - script, pre, style close tag without
 opener.
 


### PR DESCRIPTION
## Problem

These two inputs become links:
```
[link](/u(ri )
[link](/u(ri
)
```

This issue was initially reported on https://github.com/commonmark/commonmark.js/issues/177 and fixed while ago on https://github.com/commonmark/cmark/commit/58dd044ca1ea8316f4f4b6034eec12d204cc6913.

I believe this still valid as it is still live on `master` branch https://github.com/commonmark/cmark/blob/master/src/inlines.c#L480-L482, and the [spec](https://github.com/commonmark/commonmark-spec/blob/master/spec.txt#L7688-L7709) says:
> ...if you have unbalanced parentheses, you need to escape or use the `<...>` form

For some reason, it seems like it never made it to [swift-cmark](https://github.com/swiftlang/swift-cmark).