### PR TITLE
Replace UTF-8 chars with hex escape sequence

### DIFF
--- a/src/html.c
+++ b/src/html.c
@@ -74,7 +74,7 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
   cmark_strbuf_puts(html, m);
   cmark_strbuf_puts(html, "\" aria-label=\"Back to reference ");
   cmark_strbuf_puts(html, m);
-  cmark_strbuf_puts(html, "\">↩</a>");
+  cmark_strbuf_puts(html, "\xe2\x86\xa9</a>");
 
   if (node->footnote.def_count > 1)
   {
@@ -94,7 +94,7 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
       cmark_strbuf_puts(html, m);
       cmark_strbuf_puts(html, "-");
       cmark_strbuf_puts(html, n);
-      cmark_strbuf_puts(html, "\">↩<sup class=\"footnote-ref\">");
+      cmark_strbuf_puts(html, "\">\xe2\x86\xa9<sup class=\"footnote-ref\">");
       cmark_strbuf_puts(html, n);
       cmark_strbuf_puts(html, "</sup></a>");
     }


### PR DESCRIPTION
This makes the code more portable and helps build the Swift toolchain on Widnows properly no matter the user environment.

For further context, the MSVC compiler defaults to reading source files in the current environment code page. This can cause issues with UTF-8 characters in source files when attempting to read them as UTF-8. This is because the execution character set is now incompatible with the character set used during compilation, resulting in mojibake.

See swiftlang/swift#90204 for details.